### PR TITLE
fix(_id): change default tab to pending

### DIFF
--- a/src/views/_id.vue
+++ b/src/views/_id.vue
@@ -128,7 +128,7 @@ export default {
       taskTitle: '',
       drag: false,
       items: [],
-      tab: 'all',
+      tab: 'pending',
       snackbar: false
     }
   },


### PR DESCRIPTION
Re: #19 

Minor fix to change the default tab to `pending`